### PR TITLE
eliminate compiler warning

### DIFF
--- a/Rasat/Sources/DisposeBag.swift
+++ b/Rasat/Sources/DisposeBag.swift
@@ -60,7 +60,7 @@ public final class DisposeBag: Disposable {
 
 public extension Disposable {
   
-  public func disposed(by bag: DisposeBag) {
+  func disposed(by bag: DisposeBag) {
     bag.add(self)
   }
 }


### PR DESCRIPTION
'public' modifier is redundant for instance method declared in a public extension